### PR TITLE
Adding support for service authority parameter

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -75,6 +75,7 @@ Configuration can be provided as constructor options or as environment variables
 | WithLRUCache<br/>WithBasicInMemoryCache<br/>WithoutCache | FLAGD_CACHE                    | string (lru, mem, disabled) | lru       | rpc                 |
 | WithEventStreamConnectionMaxAttempts                     | FLAGD_MAX_EVENT_STREAM_RETRIES | int                         | 5         | rpc                 |
 | WithOfflineFilePath                                      | FLAGD_OFFLINE_FLAG_SOURCE_PATH | string                      | ""        | in-process          |
+| WithServiceAuthority                                     | FLAGD_SERVICE_AUTHORITY        | string                      | ""        | rpc & in-process    |
 
 ### Overriding behavior
 

--- a/providers/flagd/pkg/configuration.go
+++ b/providers/flagd/pkg/configuration.go
@@ -35,6 +35,7 @@ const (
 	flagdResolverEnvironmentVariableName              = "FLAGD_RESOLVER"
 	flagdSourceSelectorEnvironmentVariableName        = "FLAGD_SOURCE_SELECTOR"
 	flagdOfflinePathEnvironmentVariableName           = "FLAGD_OFFLINE_FLAG_SOURCE_PATH"
+	flagdServiceAuthorityEnvironmentVariableName      = "FLAGD_SERVICE_AUTHORITY"
 )
 
 type providerConfiguration struct {
@@ -50,6 +51,7 @@ type providerConfiguration struct {
 	Selector                         string
 	SocketPath                       string
 	TLSEnabled                       bool
+	ServiceAuthority                 string
 
 	log logr.Logger
 }
@@ -98,6 +100,10 @@ func (cfg *providerConfiguration) updateFromEnvVar() {
 
 		cfg.TLSEnabled = true
 		cfg.CertificatePath = certificatePath
+	}
+
+	if serviceAuthority := os.Getenv(flagdServiceAuthorityEnvironmentVariableName); serviceAuthority != "" {
+		cfg.ServiceAuthority = serviceAuthority
 	}
 
 	if maxCacheSizeS := os.Getenv(flagdMaxCacheSizeEnvironmentVariableName); maxCacheSizeS != "" {

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -59,12 +59,13 @@ func NewProvider(opts ...ProviderOption) *Provider {
 	if provider.providerConfiguration.Resolver == rpc {
 		service = rpcService.NewService(
 			rpcService.Configuration{
-				Host:            provider.providerConfiguration.Host,
-				Port:            provider.providerConfiguration.Port,
-				CertificatePath: provider.providerConfiguration.CertificatePath,
-				SocketPath:      provider.providerConfiguration.SocketPath,
-				TLSEnabled:      provider.providerConfiguration.TLSEnabled,
-				OtelInterceptor: provider.providerConfiguration.OtelIntercept,
+				Host:            	provider.providerConfiguration.Host,
+				Port:            	provider.providerConfiguration.Port,
+				CertificatePath: 	provider.providerConfiguration.CertificatePath,
+				SocketPath:      	provider.providerConfiguration.SocketPath,
+				TLSEnabled:      	provider.providerConfiguration.TLSEnabled,
+				OtelInterceptor:    provider.providerConfiguration.OtelIntercept,
+				ServiceAuthority:   provider.providerConfiguration.ServiceAuthority,
 			},
 			cacheService,
 			provider.logger,
@@ -76,6 +77,7 @@ func NewProvider(opts ...ProviderOption) *Provider {
 			Selector:          provider.providerConfiguration.Selector,
 			TLSEnabled:        provider.providerConfiguration.TLSEnabled,
 			OfflineFlagSource: provider.providerConfiguration.OfflineFlagSourcePath,
+			ServiceAuthority:  provider.providerConfiguration.ServiceAuthority,
 		})
 	}
 
@@ -278,6 +280,13 @@ func WithTLS(certPath string) ProviderOption {
 func WithOtelInterceptor(intercept bool) ProviderOption {
 	return func(p *Provider) {
 		p.providerConfiguration.OtelIntercept = intercept
+	}
+}
+
+// WithServiceAuthority sets the provided target service authority used in case of proxy (e.g. envoy)
+func WithServiceAuthority(servAuthority string) ProviderOption {
+	return func(p *Provider) {
+		p.providerConfiguration.ServiceAuthority = servAuthority
 	}
 }
 

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -59,13 +59,13 @@ func NewProvider(opts ...ProviderOption) *Provider {
 	if provider.providerConfiguration.Resolver == rpc {
 		service = rpcService.NewService(
 			rpcService.Configuration{
-				Host:            	provider.providerConfiguration.Host,
-				Port:            	provider.providerConfiguration.Port,
-				CertificatePath: 	provider.providerConfiguration.CertificatePath,
-				SocketPath:      	provider.providerConfiguration.SocketPath,
-				TLSEnabled:      	provider.providerConfiguration.TLSEnabled,
-				OtelInterceptor:    provider.providerConfiguration.OtelIntercept,
-				ServiceAuthority:   provider.providerConfiguration.ServiceAuthority,
+				Host:             provider.providerConfiguration.Host,
+				Port:             provider.providerConfiguration.Port,
+				CertificatePath:  provider.providerConfiguration.CertificatePath,
+				SocketPath:       provider.providerConfiguration.SocketPath,
+				TLSEnabled:       provider.providerConfiguration.TLSEnabled,
+				OtelInterceptor:  provider.providerConfiguration.OtelIntercept,
+				ServiceAuthority: provider.providerConfiguration.ServiceAuthority,
 			},
 			cacheService,
 			provider.logger,

--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -10,44 +10,47 @@ import (
 
 func TestNewProvider(t *testing.T) {
 	tests := []struct {
-		name                string
-		expectedResolver    ResolverType
-		expectPort          uint16
-		expectHost          string
-		expectCacheType     cache.Type
-		expectCertPath      string
-		expectMaxRetries    int
-		expectCacheSize     int
-		expectOtelIntercept bool
-		expectSocketPath    string
-		expectTlsEnabled    bool
-		options             []ProviderOption
+		name                	string
+		expectedResolver    	ResolverType
+		expectPort          	uint16
+		expectHost          	string
+		expectCacheType     	cache.Type
+		expectCertPath      	string
+		expectMaxRetries    	int
+		expectCacheSize     	int
+		expectOtelIntercept 	bool
+		expectSocketPath    	string
+		expectTlsEnabled    	bool
+		expectServiceAuthority  string
+		options             	[]ProviderOption
 	}{
 		{
-			name:                "default construction",
-			expectedResolver:    rpc,
-			expectPort:          defaultRpcPort,
-			expectHost:          defaultHost,
-			expectCacheType:     defaultCache,
-			expectCertPath:      "",
-			expectMaxRetries:    defaultMaxEventStreamRetries,
-			expectCacheSize:     defaultMaxCacheSize,
-			expectOtelIntercept: false,
-			expectSocketPath:    "",
-			expectTlsEnabled:    false,
+			name:                	"default construction",
+			expectedResolver:    	rpc,
+			expectPort:          	defaultRpcPort,
+			expectHost:          	defaultHost,
+			expectCacheType:     	defaultCache,
+			expectCertPath:      	"",
+			expectMaxRetries:    	defaultMaxEventStreamRetries,
+			expectCacheSize:     	defaultMaxCacheSize,
+			expectOtelIntercept: 	false,
+			expectSocketPath:    	"",
+			expectTlsEnabled:    	false,
+			expectServiceAuthority: "",
 		},
 		{
-			name:                "with options",
-			expectedResolver:    inProcess,
-			expectPort:          9090,
-			expectHost:          "myHost",
-			expectCacheType:     cache.LRUValue,
-			expectCertPath:      "/path",
-			expectMaxRetries:    2,
-			expectCacheSize:     2500,
-			expectOtelIntercept: true,
-			expectSocketPath:    "/socket",
-			expectTlsEnabled:    true,
+			name:                	"with options",
+			expectedResolver:    	inProcess,
+			expectPort:          	9090,
+			expectHost:          	"myHost",
+			expectCacheType:     	cache.LRUValue,
+			expectCertPath:      	"/path",
+			expectMaxRetries:    	2,
+			expectCacheSize:     	2500,
+			expectOtelIntercept: 	true,
+			expectSocketPath:    	"/socket",
+			expectTlsEnabled:    	true,
+			expectServiceAuthority: "test-service-authority",
 			options: []ProviderOption{
 				WithInProcessResolver(),
 				WithSocketPath("/socket"),
@@ -57,36 +60,39 @@ func TestNewProvider(t *testing.T) {
 				WithCertificatePath("/path"),
 				WithHost("myHost"),
 				WithPort(9090),
+				WithServiceAuthority("test-service-authority"),
 			},
 		},
 		{
-			name:                "default port handling with in-process resolver",
-			expectedResolver:    inProcess,
-			expectPort:          defaultInProcessPort,
-			expectHost:          defaultHost,
-			expectCacheType:     defaultCache,
-			expectCertPath:      "",
-			expectMaxRetries:    defaultMaxEventStreamRetries,
-			expectCacheSize:     defaultMaxCacheSize,
-			expectOtelIntercept: false,
-			expectSocketPath:    "",
-			expectTlsEnabled:    false,
+			name:                		"default port handling with in-process resolver",
+			expectedResolver:    		inProcess,
+			expectPort:          		defaultInProcessPort,
+			expectHost:          		defaultHost,
+			expectCacheType:     		defaultCache,
+			expectCertPath:      		"",
+			expectMaxRetries:    		defaultMaxEventStreamRetries,
+			expectCacheSize:     		defaultMaxCacheSize,
+			expectOtelIntercept: 		false,
+			expectSocketPath:    		"",
+			expectTlsEnabled:    		false,
+			expectServiceAuthority:     "",
 			options: []ProviderOption{
 				WithInProcessResolver(),
 			},
 		},
 		{
-			name:                "default port handling with in-process resolver",
-			expectedResolver:    rpc,
-			expectPort:          defaultRpcPort,
-			expectHost:          defaultHost,
-			expectCacheType:     defaultCache,
-			expectCertPath:      "",
-			expectMaxRetries:    defaultMaxEventStreamRetries,
-			expectCacheSize:     defaultMaxCacheSize,
-			expectOtelIntercept: false,
-			expectSocketPath:    "",
-			expectTlsEnabled:    false,
+			name:               		"default port handling with in-process resolver",
+			expectedResolver:    		rpc,
+			expectPort:          		defaultRpcPort,
+			expectHost:          		defaultHost,
+			expectCacheType:     		defaultCache,
+			expectCertPath:      		"",
+			expectMaxRetries:    		defaultMaxEventStreamRetries,
+			expectCacheSize:     		defaultMaxCacheSize,
+			expectOtelIntercept: 		false,
+			expectSocketPath:    		"",
+			expectTlsEnabled:    		false,
+			expectServiceAuthority: 	"",
 			options: []ProviderOption{
 				WithRPCResolver(),
 			},
@@ -142,6 +148,11 @@ func TestNewProvider(t *testing.T) {
 			if config.Port != test.expectPort {
 				t.Errorf("incorrect configuration Port, expected %v, got %v",
 					test.expectPort, config.Port)
+			}
+
+			if config.ServiceAuthority != test.expectServiceAuthority {
+				t.Errorf("incorrect configuration Service Authority, expected %v, got %v",
+					test.expectServiceAuthority, config.ServiceAuthority)
 			}
 
 			// this line will fail linting if this provider is no longer compatible with the openfeature sdk

--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -10,46 +10,46 @@ import (
 
 func TestNewProvider(t *testing.T) {
 	tests := []struct {
-		name                	string
-		expectedResolver    	ResolverType
-		expectPort          	uint16
-		expectHost          	string
-		expectCacheType     	cache.Type
-		expectCertPath      	string
-		expectMaxRetries    	int
-		expectCacheSize     	int
-		expectOtelIntercept 	bool
-		expectSocketPath    	string
-		expectTlsEnabled    	bool
-		expectServiceAuthority  string
-		options             	[]ProviderOption
+		name                   string
+		expectedResolver       ResolverType
+		expectPort             uint16
+		expectHost             string
+		expectCacheType        cache.Type
+		expectCertPath         string
+		expectMaxRetries       int
+		expectCacheSize        int
+		expectOtelIntercept    bool
+		expectSocketPath       string
+		expectTlsEnabled       bool
+		expectServiceAuthority string
+		options                []ProviderOption
 	}{
 		{
-			name:                	"default construction",
-			expectedResolver:    	rpc,
-			expectPort:          	defaultRpcPort,
-			expectHost:          	defaultHost,
-			expectCacheType:     	defaultCache,
-			expectCertPath:      	"",
-			expectMaxRetries:    	defaultMaxEventStreamRetries,
-			expectCacheSize:     	defaultMaxCacheSize,
-			expectOtelIntercept: 	false,
-			expectSocketPath:    	"",
-			expectTlsEnabled:    	false,
+			name:                   "default construction",
+			expectedResolver:       rpc,
+			expectPort:             defaultRpcPort,
+			expectHost:             defaultHost,
+			expectCacheType:        defaultCache,
+			expectCertPath:         "",
+			expectMaxRetries:       defaultMaxEventStreamRetries,
+			expectCacheSize:        defaultMaxCacheSize,
+			expectOtelIntercept:    false,
+			expectSocketPath:       "",
+			expectTlsEnabled:       false,
 			expectServiceAuthority: "",
 		},
 		{
-			name:                	"with options",
-			expectedResolver:    	inProcess,
-			expectPort:          	9090,
-			expectHost:          	"myHost",
-			expectCacheType:     	cache.LRUValue,
-			expectCertPath:      	"/path",
-			expectMaxRetries:    	2,
-			expectCacheSize:     	2500,
-			expectOtelIntercept: 	true,
-			expectSocketPath:    	"/socket",
-			expectTlsEnabled:    	true,
+			name:                   "with options",
+			expectedResolver:       inProcess,
+			expectPort:             9090,
+			expectHost:             "myHost",
+			expectCacheType:        cache.LRUValue,
+			expectCertPath:         "/path",
+			expectMaxRetries:       2,
+			expectCacheSize:        2500,
+			expectOtelIntercept:    true,
+			expectSocketPath:       "/socket",
+			expectTlsEnabled:       true,
 			expectServiceAuthority: "test-service-authority",
 			options: []ProviderOption{
 				WithInProcessResolver(),
@@ -64,35 +64,35 @@ func TestNewProvider(t *testing.T) {
 			},
 		},
 		{
-			name:                		"default port handling with in-process resolver",
-			expectedResolver:    		inProcess,
-			expectPort:          		defaultInProcessPort,
-			expectHost:          		defaultHost,
-			expectCacheType:     		defaultCache,
-			expectCertPath:      		"",
-			expectMaxRetries:    		defaultMaxEventStreamRetries,
-			expectCacheSize:     		defaultMaxCacheSize,
-			expectOtelIntercept: 		false,
-			expectSocketPath:    		"",
-			expectTlsEnabled:    		false,
-			expectServiceAuthority:     "",
+			name:                   "default port handling with in-process resolver",
+			expectedResolver:       inProcess,
+			expectPort:             defaultInProcessPort,
+			expectHost:             defaultHost,
+			expectCacheType:        defaultCache,
+			expectCertPath:         "",
+			expectMaxRetries:       defaultMaxEventStreamRetries,
+			expectCacheSize:        defaultMaxCacheSize,
+			expectOtelIntercept:    false,
+			expectSocketPath:       "",
+			expectTlsEnabled:       false,
+			expectServiceAuthority: "",
 			options: []ProviderOption{
 				WithInProcessResolver(),
 			},
 		},
 		{
-			name:               		"default port handling with in-process resolver",
-			expectedResolver:    		rpc,
-			expectPort:          		defaultRpcPort,
-			expectHost:          		defaultHost,
-			expectCacheType:     		defaultCache,
-			expectCertPath:      		"",
-			expectMaxRetries:    		defaultMaxEventStreamRetries,
-			expectCacheSize:     		defaultMaxCacheSize,
-			expectOtelIntercept: 		false,
-			expectSocketPath:    		"",
-			expectTlsEnabled:    		false,
-			expectServiceAuthority: 	"",
+			name:                   "default port handling with in-process resolver",
+			expectedResolver:       rpc,
+			expectPort:             defaultRpcPort,
+			expectHost:             defaultHost,
+			expectCacheType:        defaultCache,
+			expectCertPath:         "",
+			expectMaxRetries:       defaultMaxEventStreamRetries,
+			expectCacheSize:        defaultMaxCacheSize,
+			expectOtelIntercept:    false,
+			expectSocketPath:       "",
+			expectTlsEnabled:       false,
+			expectServiceAuthority: "",
 			options: []ProviderOption{
 				WithRPCResolver(),
 			},

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -35,6 +35,7 @@ type Configuration struct {
 	Selector          string
 	TLSEnabled        bool
 	OfflineFlagSource string
+	ServiceAuthority  string
 }
 
 func NewInProcessService(cfg Configuration) *InProcess {

--- a/providers/flagd/pkg/service/rpc/service.go
+++ b/providers/flagd/pkg/service/rpc/service.go
@@ -33,13 +33,13 @@ const (
 var ErrClientNotReady = of.NewProviderNotReadyResolutionError(ClientNotReadyMsg)
 
 type Configuration struct {
-	Port            	uint16
-	Host            	string
-	CertificatePath 	string
-	SocketPath      	string
-	TLSEnabled      	bool
-	OtelInterceptor 	bool
-	ServiceAuthority    string
+	Port             uint16
+	Host             string
+	CertificatePath  string
+	SocketPath       string
+	TLSEnabled       bool
+	OtelInterceptor  bool
+	ServiceAuthority string
 }
 
 // Service handles the client side  interface for the flagd server

--- a/providers/flagd/pkg/service/rpc/service.go
+++ b/providers/flagd/pkg/service/rpc/service.go
@@ -33,12 +33,13 @@ const (
 var ErrClientNotReady = of.NewProviderNotReadyResolutionError(ClientNotReadyMsg)
 
 type Configuration struct {
-	Port            uint16
-	Host            string
-	CertificatePath string
-	SocketPath      string
-	TLSEnabled      bool
-	OtelInterceptor bool
+	Port            	uint16
+	Host            	string
+	CertificatePath 	string
+	SocketPath      	string
+	TLSEnabled      	bool
+	OtelInterceptor 	bool
+	ServiceAuthority    string
 }
 
 // Service handles the client side  interface for the flagd server


### PR DESCRIPTION
## This PR
Adding a new config option that allows flagd clients to override the authority. This is useful when running gRPC sync service behind proxy e.g. envoy, istio etc. For more details, please refer this [PR](https://github.com/open-feature/java-sdk-contrib/pull/949) 

- adds this new feature

### Related Issues
https://github.com/open-feature/java-sdk-contrib/pull/949

### Notes


### Follow-up Tasks


### How to test


