### PR TITLE
Send service authority to flagd grpc service

### DIFF
--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -287,6 +287,7 @@ func makeSyncProvider(cfg Configuration, log *logger.Logger) (sync.ISync, string
 		Secure:            cfg.TLSEnabled,
 		Selector:          cfg.Selector,
 		URI:               uri,
+		ServAuthority:     cfg.ServiceAuthority,
 	}, uri
 }
 


### PR DESCRIPTION
## This PR
Sending service authority to flagd grpc service. This is in continuation of this [PR](https://github.com/bookingcom/go-sdk-contrib/pull/1)

- adds this new feature

### Related Issues
https://github.com/bookingcom/go-sdk-contrib/pull/1

### Notes


### Follow-up Tasks


### How to test


